### PR TITLE
FEAT: User sign up API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.example</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,11 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-jdbc</artifactId>
+			<version>5.0.3.RELEASE</version>
+		</dependency>
+		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
 			<scope>runtime</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -1,125 +1,130 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-	<groupId>com.example</groupId>
-	<artifactId>boilerscout</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
-	<packaging>jar</packaging>
+    <groupId>com.example</groupId>
+    <artifactId>boilerscout</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
 
-	<name>BoilerScout</name>
-	<description>Purdue CS307 Team 15</description>
+    <name>BoilerScout</name>
+    <description>Purdue CS307 Team 15</description>
 
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.0.M7</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.0.0.M7</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<java.version>1.8</java.version>
-		<spring-cloud.version>Finchley.M5</spring-cloud.version>
-	</properties>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <java.version>1.8</java.version>
+        <spring-cloud.version>Finchley.M5</spring-cloud.version>
+    </properties>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-aws-jdbc</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-aws-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-devtools</artifactId>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-jdbc</artifactId>
-			<version>5.0.3.RELEASE</version>
-		</dependency>
-		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.restdocs</groupId>
-			<artifactId>spring-restdocs-mockmvc</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-jdbc</artifactId>
+            <version>5.0.3.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.restdocs</groupId>
+            <artifactId>spring-restdocs-mockmvc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-web</artifactId>
+            <version>5.0.1.RELEASE</version>
+        </dependency>
+    </dependencies>
 
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-dependencies</artifactId>
-				<version>${spring-cloud.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 
-	<repositories>
-		<repository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>https://repo.spring.io/snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</repository>
-		<repository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-	</repositories>
+    <repositories>
+        <repository>
+            <id>spring-snapshots</id>
+            <name>Spring Snapshots</name>
+            <url>https://repo.spring.io/snapshot</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>https://repo.spring.io/milestone</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 
-	<pluginRepositories>
-		<pluginRepository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>https://repo.spring.io/snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</pluginRepository>
-		<pluginRepository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</pluginRepository>
-	</pluginRepositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>spring-snapshots</id>
+            <name>Spring Snapshots</name>
+            <url>https://repo.spring.io/snapshot</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>https://repo.spring.io/milestone</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
 
 
 </project>

--- a/src/backend/main/java/com/example/boilerscout/BoilerScoutApplication.java
+++ b/src/backend/main/java/com/example/boilerscout/BoilerScoutApplication.java
@@ -21,6 +21,8 @@ import java.util.Map;
 public class BoilerScoutApplication {
 	private static final Logger log = LoggerFactory.getLogger(Application.class);
 
+    @Autowired
+    private SignUp su;
 
 	@RequestMapping(value = "/test")
 	public String test() {
@@ -29,8 +31,7 @@ public class BoilerScoutApplication {
 
 	@RequestMapping(value = "/sign-up", method = RequestMethod.GET)
 	public List<Map<String, Object>> signUp() {
-		SignUp su = new SignUp();
-		return su.signUp();
+		return su.test();
 	}
 
 

--- a/src/backend/main/java/com/example/boilerscout/BoilerScoutApplication.java
+++ b/src/backend/main/java/com/example/boilerscout/BoilerScoutApplication.java
@@ -7,11 +7,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.dao.DataAccessException;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Map;
@@ -25,17 +21,15 @@ public class BoilerScoutApplication {
     private SignUp su;
 
 	@RequestMapping(value = "/test")
-	public String test() {
-		return "this is a test!";
-	}
+    public List<Map<String, Object>> t() {
+        return su.test();
+    }
 
-	@RequestMapping(value = "/sign-up", method = RequestMethod.GET)
-	public List<Map<String, Object>> signUp() {
-		return su.test();
-	}
-
-
-
+	@RequestMapping(value = "/sign-up", method = RequestMethod.POST)
+    @ResponseBody
+    public Map<String, Object> signUp(@RequestBody Map<String, String> body) {
+        return su.signUp(body);
+    }
 
 	public static void main(String[] args) {
 		SpringApplication.run(BoilerScoutApplication.class, args);

--- a/src/backend/main/java/com/example/boilerscout/BoilerScoutApplication.java
+++ b/src/backend/main/java/com/example/boilerscout/BoilerScoutApplication.java
@@ -2,9 +2,17 @@ package com.example.boilerscout;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
+@RestController
 @SpringBootApplication
 public class BoilerScoutApplication {
+
+	@RequestMapping(value = "/test")
+	public String test() {
+		return "this is a test!";
+	}
 
 	public static void main(String[] args) {
 		SpringApplication.run(BoilerScoutApplication.class, args);

--- a/src/backend/main/java/com/example/boilerscout/BoilerScoutApplication.java
+++ b/src/backend/main/java/com/example/boilerscout/BoilerScoutApplication.java
@@ -1,18 +1,40 @@
 package com.example.boilerscout;
 
+import com.example.boilerscout.api.SignUp;
+import javafx.application.Application;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
 
 @RestController
 @SpringBootApplication
 public class BoilerScoutApplication {
+	private static final Logger log = LoggerFactory.getLogger(Application.class);
+
 
 	@RequestMapping(value = "/test")
 	public String test() {
 		return "this is a test!";
 	}
+
+	@RequestMapping(value = "/sign-up", method = RequestMethod.GET)
+	public List<Map<String, Object>> signUp() {
+		SignUp su = new SignUp();
+		return su.signUp();
+	}
+
+
+
 
 	public static void main(String[] args) {
 		SpringApplication.run(BoilerScoutApplication.class, args);

--- a/src/backend/main/java/com/example/boilerscout/BoilerScoutApplication.java
+++ b/src/backend/main/java/com/example/boilerscout/BoilerScoutApplication.java
@@ -9,6 +9,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import java.util.List;
 import java.util.Map;
 
@@ -27,7 +28,8 @@ public class BoilerScoutApplication {
 
 	@RequestMapping(value = "/sign-up", method = RequestMethod.POST)
     @ResponseBody
-    public Map<String, Object> signUp(@RequestBody Map<String, String> body) {
+    //TODO implement meaningful exception handling for badly formatted requests
+    public Map<String, Object> signUp(@Valid @RequestBody Map<String, String> body) {
         return su.signUp(body);
     }
 

--- a/src/backend/main/java/com/example/boilerscout/api/SignUp.java
+++ b/src/backend/main/java/com/example/boilerscout/api/SignUp.java
@@ -10,25 +10,33 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.integration.IntegrationProperties;
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
 
 import javax.sql.DataSource;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Created by terrylam on 2/10/18.
  */
+@Component
 public class SignUp {
     private DataSource dataSource;
     private static final Logger log = LoggerFactory.getLogger(Application.class);
 
     @Autowired
-    JdbcTemplate jdbcTemplate;
+    private JdbcTemplate jdbcTemplate;
 
-    public List<Map<String, Object>> signUp() {
+    public void setDataSource(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public List<Map<String, Object>> test() {
         try {
+//            jdbcTemplate = new JdbcTemplate(dataSource);
             String sql = "SELECT * FROM users";
             List<Map<String, Object>> ls = jdbcTemplate.queryForList(sql);
             return ls;
@@ -37,4 +45,7 @@ public class SignUp {
             throw new RuntimeException("[InternalServerError] - Error accessing data.");
         }
     }
+
+
+
 }

--- a/src/backend/main/java/com/example/boilerscout/api/SignUp.java
+++ b/src/backend/main/java/com/example/boilerscout/api/SignUp.java
@@ -9,8 +9,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
 
 import javax.sql.DataSource;
+import javax.validation.constraints.NotEmpty;
 import java.util.*;
 
 /**
@@ -41,7 +44,6 @@ public class SignUp {
     }
 
     public Map<String, Object> signUp(@RequestBody Map<String, String> body) {
-        //TODO JSON Valiation
 
         Map<String, Object> response = new HashMap<String, Object>();
         try {
@@ -55,9 +57,13 @@ public class SignUp {
                 throw new RuntimeException("[BadRequest] - User with this email already exists!");
             }
 
+            //Hash the password passed over SSL
+            BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+            String hashedPassword = passwordEncoder.encode(password);
+
             //Insert a new user into database;
             jdbcTemplate.update("INSERT INTO users (user_id, password, email) VALUES (?, ?, ?)",
-                    newUserId, password, email);
+                    newUserId, hashedPassword, email);
             response.put("status", HttpStatus.OK);
             return response;
 

--- a/src/backend/main/java/com/example/boilerscout/api/SignUp.java
+++ b/src/backend/main/java/com/example/boilerscout/api/SignUp.java
@@ -1,0 +1,40 @@
+package com.example.boilerscout.api;
+
+import javafx.application.Application;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.integration.IntegrationProperties;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import javax.sql.DataSource;
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by terrylam on 2/10/18.
+ */
+public class SignUp {
+    private DataSource dataSource;
+    private static final Logger log = LoggerFactory.getLogger(Application.class);
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    public List<Map<String, Object>> signUp() {
+        try {
+            String sql = "SELECT * FROM users";
+            List<Map<String, Object>> ls = jdbcTemplate.queryForList(sql);
+            return ls;
+        } catch (DataAccessException ex) {
+            log.info("Exception Message" + ex.getMessage());
+            throw new RuntimeException("[InternalServerError] - Error accessing data.");
+        }
+    }
+}

--- a/src/backend/main/resources/application.properties
+++ b/src/backend/main/resources/application.properties
@@ -1,9 +1,8 @@
 cloud.aws.region.static=us-west-2
 spring.datasource.driverClassName=com.mysql.jdbc.Driver
-spring.datasource.url=jdbc:mysql://rds-mysql-boilerscout.cak4vqowr53r.us-west-2.rds.amazonaws.com
+spring.datasource.url=jdbc:mysql://rds-mysql-boilerscout.cak4vqowr53r.us-west-2.rds.amazonaws.com/boilerscout
 spring.datasource.username=root
 spring.datasource.password=cs3072018
 
 spring.jpa.database = MYSQL
 spring.jpa.show-sql = true
-

--- a/src/backend/main/resources/application.properties
+++ b/src/backend/main/resources/application.properties
@@ -1,0 +1,9 @@
+cloud.aws.region.static=us-west-2
+spring.datasource.driverClassName=com.mysql.jdbc.Driver
+spring.datasource.url=jdbc:mysql://rds-mysql-boilerscout.cak4vqowr53r.us-west-2.rds.amazonaws.com
+spring.datasource.username=root
+spring.datasource.password=cs3072018
+
+spring.jpa.database = MYSQL
+spring.jpa.show-sql = true
+


### PR DESCRIPTION
The purpose of this API is to expose an endpoint to allow users to sign up, addresses #8 
`/sign-up`

This will take in a `POST` request and output a response with either a 200 OK or 500 HTTP status code.

Example body
```
{
     email: lam45@purdue.edu,
     password: tYuDn9lsXLq
}
```

Example response
```
{
     status: OK
}
```

In the future, will need to augment this with authentication procedures.