### PR TITLE
CHORE: Create a default profile for users upon sign up

### DIFF
--- a/src/backend/main/java/com/example/boilerscout/api/SignUpController.java
+++ b/src/backend/main/java/com/example/boilerscout/api/SignUpController.java
@@ -46,6 +46,8 @@ public class SignUpController {
             String newUserId = UUID.randomUUID().toString();
             String email = body.get("email");
             String password = body.get("password");
+            String fullName = body.get("fullName");
+            String major = body.get("major");
 
             //Verify that no prior email exists
             List<Map<String, Object>> existingEmails = jdbcTemplate.queryForList("SELECT * FROM users WHERE email='" + email + "'");
@@ -60,9 +62,14 @@ public class SignUpController {
             //Insert a new user into database;
             jdbcTemplate.update("INSERT INTO users (user_id, password, email) VALUES (?, ?, ?)",
                     newUserId, hashedPassword, email);
+
+
+            //Create a new default profile for the user
+            jdbcTemplate.update("INSERT INTO profiles (user_id, full_name, major) VALUES (?, ?, ?)",
+                    newUserId, fullName, major);
+            
             response.put("status", HttpStatus.OK);
             return response;
-
         } catch (DataAccessException ex) {
             log.info("Exception Message" + ex.getMessage());
             response.put("status", HttpStatus.INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
re: @sovali @jmieczni 

We will have to slightly modify our sign up flow to include a user signing up with their `Full Name` and `Major` as well. We want to let users to continue updating their profile if they make changes to their `Biography`, `Skills`, and `Courses`, but something like their `Full Name` and `Major` will not change that often. The `profiles` table does not actually contain the list of `Skills` or `Courses` a user has, that information is projected after linking the necessary database tables.

Because of this, the `POST` request made to `/sign-up` will have to be slightly modified from
```
{
      email: ....
      password: ...
}
```

to 
```
{
     email: ....
     password: .....
     fullName: ....
     major: ...
}
```