### PR TITLE
FEAT: Retrieve threads

### DIFF
--- a/src/backend/main/java/com/example/boilerscout/BoilerScoutApplication.java
+++ b/src/backend/main/java/com/example/boilerscout/BoilerScoutApplication.java
@@ -67,6 +67,8 @@ public class BoilerScoutApplication {
         return searchController.search(userId, token, type, query);
     }
 
+
+
     @CrossOrigin
     @RequestMapping(value = "/community/start-thread", method = RequestMethod.POST)
     @ResponseBody
@@ -75,8 +77,18 @@ public class BoilerScoutApplication {
     }
 
     @CrossOrigin
+    @RequestMapping(value = "/community/get-threads", method = RequestMethod.GET)
+    @ResponseBody
+    public Map<String, Object> retrieveThreads(@RequestParam String userId,
+                                               @RequestParam String token,
+                                               @RequestParam String forumId) {
+        return forumController.getThreads(userId, token, forumId);
+    }
+
+
+    @CrossOrigin
     @RequestMapping(value = "/community", method = RequestMethod.GET)
-    public Map<String, Object> queryForUsers(@RequestParam String userId,
+    public Map<String, Object> retrieveForums(@RequestParam String userId,
                                              @RequestParam String token) {
         return forumController.getForums(userId, token);
     }

--- a/src/backend/main/java/com/example/boilerscout/api/ForumController.java
+++ b/src/backend/main/java/com/example/boilerscout/api/ForumController.java
@@ -96,6 +96,29 @@ public class ForumController extends ValidationUtility {
 
     }
 
+    public Map<String, Object> getThreads(@RequestParam String userId,
+                                          @RequestParam String token,
+                                          @RequestParam String forumId) {
+        Map<String, Object> response = new HashMap<String, Object>();
+        response.put("userId", userId);
+        response.put("token", token);
+        if (!isValidToken(token, userId) || isExpiredToken(token)) {
+            response.put("status", HttpStatus.INTERNAL_SERVER_ERROR + " - This token is not valid!");
+            return response;
+        } else {
+            try {
+                List<Map<String, Object>> listOfThreads = jdbcTemplate.queryForList("SELECT * FROM threads WHERE forum_id='" + forumId + "'");
+                response.put("threads", listOfThreads);
+            } catch (DataAccessException ex) {
+                log.info("Exception Message" + ex.getMessage());
+                response.put("status", HttpStatus.INTERNAL_SERVER_ERROR);
+                throw new RuntimeException("[InternalServerError] - Error accessing data.");
+            }
+        }
+        response.put("status", HttpStatus.OK);
+        return response;
+    }
+
 
     public Map<String, Object> startThread(@RequestBody Map<String, Object> body) {
 

--- a/src/backend/main/java/com/example/boilerscout/api/ForumController.java
+++ b/src/backend/main/java/com/example/boilerscout/api/ForumController.java
@@ -107,7 +107,8 @@ public class ForumController extends ValidationUtility {
             return response;
         } else {
             try {
-                List<Map<String, Object>> listOfThreads = jdbcTemplate.queryForList("SELECT * FROM threads WHERE forum_id='" + forumId + "'");
+                String query = "SELECT t.*, p.full_name FROM threads t INNER JOIN profiles p ON t.user_id = p.user_id WHERE forum_id='" + forumId + "'";
+                List<Map<String, Object>> listOfThreads = jdbcTemplate.queryForList(query);
                 response.put("threads", listOfThreads);
             } catch (DataAccessException ex) {
                 log.info("Exception Message" + ex.getMessage());


### PR DESCRIPTION
The purpose of this pull request is to expose an endpoint to retrieve threads for any one of our forums in the application. The endpoint to hit is `/community/get-threads` that takes in a `GET` request with the following parameters

`userId` - user id of the person
`token` - JWT of the person
`forumId` - forum id of the forum the person is viewing

A typical response body would look like this
```json
{
    "threads": [
        {
            "thread_id": "4fc3622f-fe9a-41fc-8d5e-8609a70a3df0",
            "forum_id": "f3a1e4d0-22d8-4fd0-9a47-345c109001b3",
            "user_id": "65e580de-6c9e-40ab-8c10-abdf69a02180",
            "thread_title": "CS252 - Lab 6 Help",
            "thread_body": "I suck at this class and i need help",
            "thread_date": "2018-04-01T19:01:25.000+0000",
            "full_name": "Terry Lam"
        },
        {
            "thread_id": "b30dcc1e-15af-45b1-a544-bb33ad9c02d0",
            "forum_id": "f3a1e4d0-22d8-4fd0-9a47-345c109001b3",
            "user_id": "65e580de-6c9e-40ab-8c10-abdf69a02180",
            "thread_title": "CS348 Project 2",
            "thread_body": "I haven't started",
            "thread_date": "2018-04-01T19:02:09.000+0000",
            "full_name": "Terry Lam"
        },
        {
            "thread_id": "e648296b-6940-46cc-8a56-f62f3de0c8cf",
            "forum_id": "f3a1e4d0-22d8-4fd0-9a47-345c109001b3",
            "user_id": "65e580de-6c9e-40ab-8c10-abdf69a02180",
            "thread_title": "CS307 - HW 3",
            "thread_body": "This assignment is dumb",
            "thread_date": "2018-04-01T19:01:56.000+0000",
            "full_name": "Terry Lam"
        }
    ],
    "userId": "65e580de-6c9e-40ab-8c10-abdf69a02180",
    "token": "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJsYW00NUBwdXJkdWUuZWR1IiwidXNlcklkIjoiNjVlNTgwZGUtNmM5ZS00MGFiLThjMTAtYWJkZjY5YTAyMTgwIiwiZXhwIjoxNTIzNDE0ODQ2fQ.ic-4NK1QMY4dFSa8dHsthLoYc7-c8Fy1kKnZCxbhybmYlnKLrvgoBOZ6IG3Sqq9uy8M_ir0cuHMnor4aMS8qNQ",
    "status": "OK"
}
```

Notice that the `threads` object returns a list of all the threads associated with a particular forum. From a client perspective, the main things we want to display are 

`full_name` - name of the person who posted the thread
`thread_title` - title of the thread
`thread_date` - date the thread was posted

You are free to use any of the other fields as you see fit. Upon sending a request with an invalid forum id, the query list for `threads` returns empty.