### PR TITLE
FEAT: Functionality for a user to log out

### DIFF
--- a/src/backend/main/java/com/example/boilerscout/BoilerScoutApplication.java
+++ b/src/backend/main/java/com/example/boilerscout/BoilerScoutApplication.java
@@ -23,7 +23,7 @@ public class BoilerScoutApplication {
     private SignUpController signUpController;
 
     @Autowired
-    private LoginController loginController;
+    private AuthenticationController authenticationController;
 
     @Autowired
     private ProfileController profileController;
@@ -32,7 +32,6 @@ public class BoilerScoutApplication {
     private SearchController searchController;
 
     @Autowired
-
     private ForumController forumController;
 
 
@@ -41,11 +40,6 @@ public class BoilerScoutApplication {
 
     @Autowired
     private VerificationController verificationController;
-//
-//    @RequestMapping(value = "/test")
-//    public Map<String, Object> t(@RequestBody Map<String, String> body) {
-//        return signUpController.test(body);
-//    }
 
 
     @CrossOrigin
@@ -59,9 +53,15 @@ public class BoilerScoutApplication {
     @CrossOrigin
     @RequestMapping(value = "/login", method = RequestMethod.POST)
     @ResponseBody
-    public Map<String, Object> login(@Valid @RequestBody Map<String, String> body) {
-        return loginController.login(body);
+    public Map<String, Object> login(@Valid @RequestBody Map<String, Object> body) {
+        return authenticationController.login(body);
+    }
 
+    @CrossOrigin
+    @RequestMapping(value = "/logout", method = RequestMethod.POST)
+    @ResponseBody
+    public Map<String, Object> logout(@Valid @RequestBody Map<String, Object> body) {
+        return authenticationController.logout(body);
     }
 
     @CrossOrigin

--- a/src/backend/main/java/com/example/boilerscout/api/AuthenticationController.java
+++ b/src/backend/main/java/com/example/boilerscout/api/AuthenticationController.java
@@ -23,7 +23,7 @@ import java.util.Map;
  */
 
 @Service
-public class LoginController {
+public class AuthenticationController extends ValidationUtility {
     private static final Logger log = LoggerFactory.getLogger(Application.class);
     static final long EXPIRATIONTIME = 864_000_000; // 10 days
     static final String SECRET = "TerryLam";
@@ -33,12 +33,12 @@ public class LoginController {
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
-    public Map<String, Object> login(@RequestBody Map<String, String> body) {
+    public Map<String, Object> login(@RequestBody Map<String, Object> body) {
 
         Map<String, Object> response = new HashMap<String, Object>();
         try {
-            String email = body.get("email");
-            String password = body.get("password");
+            String email = body.get("email").toString();
+            String password = body.get("password").toString();
             BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
             //Check if email exists
@@ -73,11 +73,29 @@ public class LoginController {
             //Insert the token into the database
             jdbcTemplate.update("UPDATE users SET authentication_token='" + JWT + "'" + " WHERE email ='" + email + "'");
 
-            //TODO add authorization to endpoints
-
-            response.put("user_id", user_id);
+            response.put("userId", user_id);
             response.put("token", JWT);
 
+        } catch (DataAccessException ex) {
+            log.info("Exception Message" + ex.getMessage());
+            response.put("status", HttpStatus.INTERNAL_SERVER_ERROR);
+            throw new RuntimeException("[InternalServerError] - Error accessing data.");
+        }
+        return response;
+    }
+
+    public Map<String, Object> logout(@RequestBody Map<String,Object> body) {
+        Map<String, Object> response = new HashMap<String, Object>();
+        try {
+            String userId = body.get("userId").toString();
+            String token = body.get("token").toString();
+            if (!isValidToken(token, userId) || isExpiredToken(token)) {
+                response.put("status", HttpStatus.INTERNAL_SERVER_ERROR + " - This token is not valid!");
+                return response;
+            } else {
+                jdbcTemplate.update("UPDATE users SET authentication_token = NULL WHERE user_id='" + userId + "'");
+                response.put("status", HttpStatus.OK);
+            }
         } catch (DataAccessException ex) {
             log.info("Exception Message" + ex.getMessage());
             response.put("status", HttpStatus.INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
The purpose of his pull request is to expose an endpoint for logging out a user (thus wiping his or her current access token from the database).

The endpoint is located at `/logout`, and is a `POST` request that takes in two request parameters
`userId` and `token`. When this endpoint is hit, we check one last time to ensure that the user is authorized to make this call, and if so, their JWT (`authentication_token` attribute in the database table) is deleted.

@jmieczni 