### PR TITLE
FIX:  Prevent users verified status from devolving.

### DIFF
--- a/src/backend/main/java/com/example/boilerscout/api/EmailServiceController.java
+++ b/src/backend/main/java/com/example/boilerscout/api/EmailServiceController.java
@@ -63,7 +63,7 @@ public class EmailServiceController extends ValidationUtility {
             if(currentStatus==1){
                 response.put("userId",userId);
                 response.put("Message","Already verified.");
-                response.put("Status","400");
+                response.put("status",HttpStatus.BAD_REQUEST);
                 return response;
             }
             String to = email;
@@ -74,7 +74,7 @@ public class EmailServiceController extends ValidationUtility {
             String subject ="BoilerScout. Account verification.";
             String text = "Hi,\nYou are now one step closer to your BoilerScout account.\n\nPlease verifiy your account with the following link:\n\n\tlocalhost:8080/verify?id=";
             sendSimpleMessage(to,subject,text + userId + "&query=" + verificationCode);
-            response.put("Status","200");
+            response.put("status",HttpStatus.OK);
             response.put("userId",userId);
             return response;
 
@@ -112,7 +112,7 @@ public class EmailServiceController extends ValidationUtility {
             text = text + "&id=" + userId;  //append id, these are both for sec checks
             sendSimpleMessage(to,subject,text);
             
-            response.put("Status","200");
+            response.put("status",HttpStatus.OK);
             response.put("userId",userId);
             return response;
 

--- a/src/backend/main/java/com/example/boilerscout/api/EmailServiceController.java
+++ b/src/backend/main/java/com/example/boilerscout/api/EmailServiceController.java
@@ -59,14 +59,22 @@ public class EmailServiceController extends ValidationUtility {
         try {
             //got email
             String userId = jdbcTemplate.queryForObject("SELECT user_id FROM users WHERE email='" + email + "'", String.class);
+            int currentStatus =  jdbcTemplate.queryForObject("SELECT email_verified FROM users WHERE email='" + email + "'", int.class);
+            if(currentStatus==1){
+                response.put("userId",userId);
+                response.put("Message","Already verified.");
+                response.put("Status","400");
+                return response;
+            }
             String to = email;
             //generate new verification code
             int verificationCode = ThreadLocalRandom.current().nextInt(100000, 1999999999);
+
             jdbcTemplate.update("UPDATE users SET email_verified=" + verificationCode + " WHERE user_id='" + userId + "'");
             String subject ="BoilerScout. Account verification.";
             String text = "Hi,\nYou are now one step closer to your BoilerScout account.\n\nPlease verifiy your account with the following link:\n\n\tlocalhost:8080/verify?id=";
             sendSimpleMessage(to,subject,text + userId + "&query=" + verificationCode);
-            response.put("ok","ok");
+            response.put("Status","200");
             response.put("userId",userId);
             return response;
 
@@ -104,7 +112,7 @@ public class EmailServiceController extends ValidationUtility {
             text = text + "&id=" + userId;  //append id, these are both for sec checks
             sendSimpleMessage(to,subject,text);
             
-            response.put("ok","ok");
+            response.put("Status","200");
             response.put("userId",userId);
             return response;
 

--- a/src/backend/main/java/com/example/boilerscout/api/ProfileController.java
+++ b/src/backend/main/java/com/example/boilerscout/api/ProfileController.java
@@ -171,6 +171,7 @@ public Map<String, Object> getProfile(@RequestParam String userId, @RequestParam
                         response.put("Courses",courses);
                     }
                 }
+                response.put("status", HttpStatus.OK);
                 return response;
 //user lacks either a bio, courses, or skill, so we need to find out which.
             } else {
@@ -222,7 +223,7 @@ public Map<String, Object> getProfile(@RequestParam String userId, @RequestParam
                 tempInfo = jdbcTemplate.queryForList("SELECT email from users where user_id =  '" + query +"'");
 
                 response.put("Email",tempInfo.get(0).get("email"));
-
+                response.put("status", HttpStatus.OK);
                 return response;
             }
 

--- a/src/backend/main/java/com/example/boilerscout/api/SettingsController.java
+++ b/src/backend/main/java/com/example/boilerscout/api/SettingsController.java
@@ -93,7 +93,7 @@ public class SettingsController extends ValidationUtility {
         String hashId = encoder.encode(userId);
         Map<String, Object> response = new HashMap<String, Object>();
         response.put("userId",userId);
-        response.put("status","valid");
+        response.put("status", HttpStatus.OK);
         response.put("hashedEmail",hashedEmail);
         response.put("hashedId",hashId);
 
@@ -137,7 +137,7 @@ public class SettingsController extends ValidationUtility {
                 newPass = '"'+newPass+'"';
                 jdbcTemplate.update("UPDATE users SET password=" + newPass + " WHERE user_id='" + userId + "'");
 
-                response.put("status","Successful Reset");
+                response.put("status",HttpStatus.OK);
                 response.put("userId",userId);
 
 

--- a/src/backend/main/java/com/example/boilerscout/api/VerificationController.java
+++ b/src/backend/main/java/com/example/boilerscout/api/VerificationController.java
@@ -50,14 +50,14 @@ public class VerificationController extends EmailServiceController{
                     if(verificationStatus.get(0).get("email_verified").equals(verificationCode)){
                         jdbcTemplate.update("UPDATE users SET email_verified=" + 1 + " WHERE user_id='" + userId + "'");
                         response.put("Response","Verified");
-                        response.put("Status","200");
+                        response.put("status",HttpStatus.OK);
                         return response;
                     } else {
                         //NO MATCH, inform this verification email isnt valid
                         String message = "This verification email has either expired, or is not valid.";
                         message = message + "  Please check your inbox for a more recent one, or request a new one.";
                         response.put("Response",message);
-                        response.put("Status", "400");
+                        response.put("status", HttpStatus.OK);
                         response.put("email_verified",(verificationStatus.get(0).get("email_verified")));
                         response.put("test",compare);
                         response.put("verification code", verificationCode);
@@ -69,13 +69,13 @@ public class VerificationController extends EmailServiceController{
                 } else {
                     //response.put("St",verificationStatus.get(0));
                     response.put("Response","Email previously verified.");
-                    response.put("Status","400");
+                    response.put("status",HttpStatus.BAD_REQUEST);
                     return response;
                 }
             }else {
                 //Should never reach here, as all users should have a verified field
                 response.put("Response", "Critical error, email or id do not exist");
-                response.put("Status","400");
+                response.put("status",HttpStatus.BAD_REQUEST);
                 return response;
             }
         } catch (DataAccessException ex) {


### PR DESCRIPTION
Tweaked status returns all around a few controllers (ProfileController, SettingsController, EmailController, VerificationController) to match standard (e.g 200, 400) and avoided hard coding the codes.  Also two changes:

1) Previously the method would allow users with a verified status to still request new emails, which would change their status and prevent them from using the app.  Now, once a user acquires a 1 status (verified) it cant be changed in any way.

2)
Both methods in the controller: `sendVerification`( which is tied to `/send/verification`), `sendNewPasswordLink` (tied to `/send/forgot-pass`, now return at least the following when valid:

```
{
    "Status":"200",
    "userId":"8673508d-7fae-4299-a547-0087200c4bfc"
}
```

