### PR TITLE
FIX: Add unique ids for messages and optimize imports

### DIFF
--- a/src/backend/main/java/com/example/boilerscout/api/MessageController.java
+++ b/src/backend/main/java/com/example/boilerscout/api/MessageController.java
@@ -12,13 +12,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import java.sql.Types;
+import java.sql.Timestamp;
 import java.util.*;
-
-
-/*
-Created  by Baris Dingil
-*/
 
 @Service
 public class MessageController extends ValidationUtility {
@@ -31,10 +26,14 @@ public class MessageController extends ValidationUtility {
     public Map<String, Object> sendMessage(@RequestBody Map<String, String> body) {
 
         Map<String, Object> response = new HashMap<String, Object>();
+        Date d = new Date();
+        Timestamp messageDate = new Timestamp(d.getTime());
+
         String recipientEmail = body.get("recipientEmail");
         String message = body.get("messageBody");
         String userId = body.get("userId");
         String token = body.get("token");
+        String newMessageId = UUID.randomUUID().toString();
 
         if (!isValidToken(token, userId) || isExpiredToken(token)) {
             response.put("status", HttpStatus.INTERNAL_SERVER_ERROR + " - This token is not valid!");
@@ -42,25 +41,18 @@ public class MessageController extends ValidationUtility {
         } else {
             try {
                 String recipientId = jdbcTemplate.queryForObject("SELECT user_id FROM users WHERE email ='" + recipientEmail + "'", String.class);
-
-                java.sql.Timestamp messageDate = new java.sql.Timestamp(System.currentTimeMillis());
-
-                jdbcTemplate.update("INSERT INTO user_messages (recipient_id, sender_id, message_body, message_date) VALUES (?, ?, ?,?)", recipientId, userId, message, messageDate);
-
+                jdbcTemplate.update("INSERT INTO user_messages (message_id, recipient_id, sender_id, message_body, message_date) VALUES (?, ?, ?, ?,?)", newMessageId, recipientId, userId, message, messageDate);
                 response.put("status", HttpStatus.OK);
             } catch (DataAccessException e) {
-
                 log.info("Exception Message" + e.getMessage());
                 response.put("status", HttpStatus.INTERNAL_SERVER_ERROR);
                 throw new RuntimeException("[InternalServerError] - Error accessing data.");
-
             }
-
             return response;
         }
     }
 
-    public Map<String, Object> getInbox (@RequestParam String userId, @RequestParam String sort, @RequestParam String token) {
+    public Map<String, Object> getInbox(@RequestParam String userId, @RequestParam String sort, @RequestParam String token) {
 
         Map<String, Object> response = new HashMap<String, Object>();
 
@@ -71,20 +63,19 @@ public class MessageController extends ValidationUtility {
         if (!isValidToken(token, userId) || isExpiredToken(token)) {
             response.put("status", HttpStatus.INTERNAL_SERVER_ERROR + " - This token is not valid!");
             return response;
-
         } else {
             try {
                 List<Map<String, Object>> userInbox = new ArrayList<Map<String, Object>>();
 
                 switch (sort) {
                     case "ASC":
-                        userInbox = jdbcTemplate.queryForList("SELECT um.message_body, p.full_name, u.email, um.message_date FROM user_messages um INNER JOIN profiles p ON um.sender_id=p.user_id INNER JOIN users u ON u.user_id=um.sender_id WHERE recipient_id='" + userId + "'ORDER BY message_date ASC");
+                        userInbox = jdbcTemplate.queryForList("SELECT um.message_id, um.message_body, p.full_name, u.email, um.message_date FROM user_messages um INNER JOIN profiles p ON um.sender_id=p.user_id INNER JOIN users u ON u.user_id=um.sender_id WHERE recipient_id='" + userId + "'ORDER BY message_date ASC");
                         break;
                     case "DESC":
-                        userInbox = jdbcTemplate.queryForList("SELECT um.message_body, p.full_name, u.email, um.message_date FROM user_messages um INNER JOIN profiles p ON um.sender_id=p.user_id INNER JOIN users u ON u.user_id=um.sender_id WHERE recipient_id='" + userId + "'ORDER BY message_date DESC ");
+                        userInbox = jdbcTemplate.queryForList("SELECT um.message_id, um.message_body, p.full_name, u.email, um.message_date FROM user_messages um INNER JOIN profiles p ON um.sender_id=p.user_id INNER JOIN users u ON u.user_id=um.sender_id WHERE recipient_id='" + userId + "'ORDER BY message_date DESC ");
                         break;
                     default:
-                        userInbox = jdbcTemplate.queryForList("SELECT um.message_body, p.full_name, u.email, um.message_date FROM user_messages um INNER JOIN profiles p ON um.sender_id=p.user_id INNER JOIN users u ON u.user_id=um.sender_id WHERE recipient_id='" + userId + "'ORDER BY message_date ASC");
+                        userInbox = jdbcTemplate.queryForList("SELECT um.message_id, um.message_body, p.full_name, u.email, um.message_date FROM user_messages um INNER JOIN profiles p ON um.sender_id=p.user_id INNER JOIN users u ON u.user_id=um.sender_id WHERE recipient_id='" + userId + "'ORDER BY message_date ASC");
                         break;
                 }
                 response.put("userInbox", userInbox);
@@ -93,13 +84,12 @@ public class MessageController extends ValidationUtility {
                 log.info("Exception Message" + e.getMessage());
                 response.put("status", HttpStatus.INTERNAL_SERVER_ERROR);
                 throw new RuntimeException("[InternalServerError] - Error accessing data.");
-
             }
             return response;
         }
     }
 
-    public Map<String, Object> getOutbox (@RequestParam String userId, @RequestParam String sort, @RequestParam String token) {
+    public Map<String, Object> getOutbox(@RequestParam String userId, @RequestParam String sort, @RequestParam String token) {
 
         Map<String, Object> response = new HashMap<String, Object>();
 
@@ -110,31 +100,26 @@ public class MessageController extends ValidationUtility {
         if (!isValidToken(token, userId) || isExpiredToken(token)) {
             response.put("status", HttpStatus.INTERNAL_SERVER_ERROR + " - This token is not valid!");
             return response;
-
         } else {
-
             try {
                 List<Map<String, Object>> userOutbox = new ArrayList<Map<String, Object>>();
                 switch (sort) {
                     case "ASC":
-                        userOutbox = jdbcTemplate.queryForList("SELECT um.message_body, p.full_name, u.email, um.message_date FROM user_messages um INNER JOIN profiles p ON um.recipient_id=p.user_id INNER JOIN users u ON u.user_id=um.recipient_id WHERE sender_id='" + userId + "'ORDER BY message_date ASC");
+                        userOutbox = jdbcTemplate.queryForList("SELECT um.message_id, um.message_body, p.full_name, u.email, um.message_date FROM user_messages um INNER JOIN profiles p ON um.recipient_id=p.user_id INNER JOIN users u ON u.user_id=um.recipient_id WHERE sender_id='" + userId + "'ORDER BY message_date ASC");
                         break;
                     case "DESC":
-                        userOutbox = jdbcTemplate.queryForList("SELECT um.message_body, p.full_name, u.email, um.message_date FROM user_messages um INNER JOIN profiles p ON um.recipient_id=p.user_id INNER JOIN users u ON u.user_id=um.recipient_id WHERE sender_id='" + userId + "'ORDER BY message_date ASC");
+                        userOutbox = jdbcTemplate.queryForList("SELECT um.message_id, um.message_body, p.full_name, u.email, um.message_date FROM user_messages um INNER JOIN profiles p ON um.recipient_id=p.user_id INNER JOIN users u ON u.user_id=um.recipient_id WHERE sender_id='" + userId + "'ORDER BY message_date ASC");
                         break;
                     default:
-                        userOutbox = jdbcTemplate.queryForList("SELECT um.message_body, p.full_name, u.email, um.message_date FROM user_messages um INNER JOIN profiles p ON um.recipient_id=p.user_id INNER JOIN users u ON u.user_id=um.recipient_id WHERE sender_id='" + userId + "'ORDER BY message_date ASC");
+                        userOutbox = jdbcTemplate.queryForList("SELECT um.message_id, um.message_body, p.full_name, u.email, um.message_date FROM user_messages um INNER JOIN profiles p ON um.recipient_id=p.user_id INNER JOIN users u ON u.user_id=um.recipient_id WHERE sender_id='" + userId + "'ORDER BY message_date ASC");
                         break;
                 }
                 response.put("userOutbox", userOutbox);
                 response.put("status", HttpStatus.OK);
-
             } catch (DataAccessException e) {
-
                 log.info("Exception Message" + e.getMessage());
                 response.put("status", HttpStatus.INTERNAL_SERVER_ERROR);
                 throw new RuntimeException("[InternalServerError] - Error accessing data.");
-
             }
             return response;
         }

--- a/src/backend/main/java/com/example/boilerscout/api/SettingsController.java
+++ b/src/backend/main/java/com/example/boilerscout/api/SettingsController.java
@@ -12,7 +12,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
 @Service
 public class SettingsController extends ValidationUtility {
 

--- a/src/backend/main/java/com/example/boilerscout/api/SignUpController.java
+++ b/src/backend/main/java/com/example/boilerscout/api/SignUpController.java
@@ -1,7 +1,5 @@
 package com.example.boilerscout.api;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
 import javafx.application.Application;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,13 +7,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
-
-import javax.xml.bind.DatatypeConverter;
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 /**
  * Created by terrylam on 2/10/18.

--- a/src/backend/main/java/com/example/boilerscout/api/ValidationUtility.java
+++ b/src/backend/main/java/com/example/boilerscout/api/ValidationUtility.java
@@ -1,6 +1,8 @@
 package com.example.boilerscout.api;
 
-import io.jsonwebtoken.*;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
 import javafx.application.Application;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,7 +11,6 @@ import org.springframework.jdbc.core.JdbcTemplate;
 
 import javax.xml.bind.DatatypeConverter;
 import java.util.Date;
-import java.util.UUID;
 
 /**
  * Created by terrylam on 2/19/18.

--- a/src/backend/main/java/com/example/boilerscout/api/VerificationController.java
+++ b/src/backend/main/java/com/example/boilerscout/api/VerificationController.java
@@ -1,9 +1,6 @@
 package com.example.boilerscout.api;
 
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.JwtException;
-import io.jsonwebtoken.Jwts;
 import javafx.application.Application;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -11,17 +8,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.mail.SimpleMailMessage;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.RequestBody;
 
-import javax.xml.bind.DatatypeConverter;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.*;
-import javax.mail.*;
-import javax.mail.internet.*;
-import javax.activation.*;
 
 @Service
 public class VerificationController extends EmailServiceController{


### PR DESCRIPTION
Modified the table `user_messages` to include a new primary key (`message_id`). This is necessary for any future enhancements we want to make to our messaging, inbox, and outbox functionality (i.e deleting messages).